### PR TITLE
chore: ensure payload-trash plugin can have exceptions to certain collections

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -144,6 +144,7 @@ export default buildConfig({
     trashBin({
       // displayToRoles: ['all'] // default value
       displayToRoles: ['admin'], // visible only to admins
+      doNotEnableTrash: ['cart', 'wishlist'],
     }),
     // Retrieve URL from environment variables or configuration settings.
     // mediaCloudflareURLHandler({

--- a/src/plugins/payload-trashbin/collections/trash.ts
+++ b/src/plugins/payload-trashbin/collections/trash.ts
@@ -5,7 +5,7 @@ import { RestoreButton } from '../components/RestoreButton'
 // This is a object converter that converts any  expanded relation including nested to plain relation (where the value of the relation is just the id)
 function convertObject(obj: any) {
   Object.keys(obj).forEach(key => {
-    if (Object.hasOwn(obj[key], 'relationTo')) {
+    if (Object.prototype.hasOwnProperty.call(obj[key], 'relationTo')) {
       obj[key].value = obj[key].value.id
     }
   })

--- a/src/plugins/payload-trashbin/types.ts
+++ b/src/plugins/payload-trashbin/types.ts
@@ -20,4 +20,5 @@ export interface PluginTypes {
     },
    */
   displayToRoles?: string[]
+  doNotEnableTrash?: string[]
 }


### PR DESCRIPTION
Adding a new payload option called, `doNotEnableTrash` which takes an array of collections to which the plugin will not be enabled