### PR TITLE
Custom relationship filed

### DIFF
--- a/src/collections/Ticket/custom/custom-contest-relationship-field/component.tsx
+++ b/src/collections/Ticket/custom/custom-contest-relationship-field/component.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react'
+
+import {
+  Props,
+  RelationshipComponent,
+  ValueWithRelation,
+} from 'payload/components/fields/Relationship'
+import { useFormFields } from 'payload/components/forms'
+import { Fields } from 'payload/types'
+
+export const CustomContestRelationshipComponent: React.FC<Props> = props => {
+  const {
+    relationTo,
+    path,
+    name,
+    required,
+    label,
+    hasMany,
+    filterOptions,
+    access,
+    custom,
+    defaultValue,
+    hidden,
+    hooks,
+    index,
+    localized,
+    maxDepth,
+    maxRows,
+    minRows,
+    saveToJWT,
+    unique,
+    validate,
+    admin,
+  } = props
+
+  // Field values can be accessed and updated using the commented `useField` function as well.
+
+  // const { value: relationship, setValue: setRelationShip } =
+  //   useField<ValueWithRelation>({ path: path || '' })
+
+  // const { value: ticketPrice, setValue: setTicketPrice } = useField<number>({
+  //   path: 'ticket_price',
+  // })
+
+  // Retrieve field state and dispatch function using useFormFields hook
+  const { fields, dispatch } = useFormFields(([fields, dispatch]) => ({
+    fields,
+    dispatch,
+  }))
+
+  // Extract contest_id field value from fields object
+  const { contest_id: contestId } = fields as Fields
+
+  // Fetch contest data when contestId value changes
+  React.useEffect(() => {
+    const fetchContest = async () => {
+      try {
+        const req = await fetch(
+          `/api/contest/${(contestId.value as ValueWithRelation).value}`,
+        )
+        const contest = await req.json()
+
+        // Dispatch an action to update the ticket_price field value
+        dispatch({
+          type: 'UPDATE',
+          path: 'ticket_price',
+          value: contest?.ticket_price,
+        })
+      } catch (error) {
+        console.log(
+          'Error fetching contest in custom relationship component: ',
+          error,
+        )
+      }
+    }
+
+    fetchContest()
+  }, [contestId.value, dispatch])
+
+  return (
+    // Render the RelationshipComponent with provided props
+    <RelationshipComponent
+      key={'custom-relation-component-for-contest'}
+      name={name}
+      relationTo={relationTo}
+      label={label}
+      filterOptions={filterOptions}
+      required={required}
+      access={access}
+      admin={admin}
+      custom={custom}
+      defaultValue={defaultValue}
+      hasMany={hasMany}
+      hidden={hidden}
+      hooks={hooks}
+      index={index}
+      localized={localized}
+      maxDepth={maxDepth}
+      maxRows={maxRows}
+      minRows={minRows}
+      path={path}
+      saveToJWT={saveToJWT}
+      unique={unique}
+      validate={validate}
+    />
+  )
+}

--- a/src/collections/Ticket/custom/custom-contest-relationship-field/component.tsx
+++ b/src/collections/Ticket/custom/custom-contest-relationship-field/component.tsx
@@ -9,30 +9,6 @@ import { useFormFields } from 'payload/components/forms'
 import { Fields } from 'payload/types'
 
 export const CustomContestRelationshipComponent: React.FC<Props> = props => {
-  const {
-    relationTo,
-    path,
-    name,
-    required,
-    label,
-    hasMany,
-    filterOptions,
-    access,
-    custom,
-    defaultValue,
-    hidden,
-    hooks,
-    index,
-    localized,
-    maxDepth,
-    maxRows,
-    minRows,
-    saveToJWT,
-    unique,
-    validate,
-    admin,
-  } = props
-
   // Field values can be accessed and updated using the commented `useField` function as well.
 
   // const { value: relationship, setValue: setRelationShip } =
@@ -81,27 +57,7 @@ export const CustomContestRelationshipComponent: React.FC<Props> = props => {
     // Render the RelationshipComponent with provided props
     <RelationshipComponent
       key={'custom-relation-component-for-contest'}
-      name={name}
-      relationTo={relationTo}
-      label={label}
-      filterOptions={filterOptions}
-      required={required}
-      access={access}
-      admin={admin}
-      custom={custom}
-      defaultValue={defaultValue}
-      hasMany={hasMany}
-      hidden={hidden}
-      hooks={hooks}
-      index={index}
-      localized={localized}
-      maxDepth={maxDepth}
-      maxRows={maxRows}
-      minRows={minRows}
-      path={path}
-      saveToJWT={saveToJWT}
-      unique={unique}
-      validate={validate}
+      {...props}
     />
   )
 }

--- a/src/collections/Ticket/custom/custom-contest-relationship-field/field.ts
+++ b/src/collections/Ticket/custom/custom-contest-relationship-field/field.ts
@@ -10,7 +10,6 @@ export const customContestRelationshipField: Field = {
   required: true,
   admin: {
     description: 'The contest associated with this ticket.',
-    position: 'sidebar',
     components: {
       Field: CustomContestRelationshipComponent,
     },

--- a/src/collections/Ticket/custom/custom-contest-relationship-field/field.ts
+++ b/src/collections/Ticket/custom/custom-contest-relationship-field/field.ts
@@ -1,0 +1,29 @@
+import { Field } from 'payload/types'
+import { CustomContestRelationshipComponent } from './component'
+
+export const customContestRelationshipField: Field = {
+  name: 'contest_id',
+  type: 'relationship',
+  label: 'Contest Id',
+  relationTo: ['contest'],
+  hasMany: false,
+  required: true,
+  admin: {
+    description: 'The contest associated with this ticket.',
+    position: 'sidebar',
+    components: {
+      Field: CustomContestRelationshipComponent,
+    },
+  },
+  filterOptions: ({ relationTo, data, id }) => {
+    if (relationTo === 'contest') {
+      return {
+        contest_status: {
+          equals: false,
+        },
+      }
+    }
+
+    return false
+  },
+}

--- a/src/collections/Ticket/index.ts
+++ b/src/collections/Ticket/index.ts
@@ -28,61 +28,63 @@ const Ticket: CollectionConfig = {
     {
       type: 'row',
       fields: [
+        { ...customContestRelationshipField },
         {
-          name: 'ticket_number',
-          type: 'text',
-          label: 'Ticket Number',
-          unique: true,
-          defaultValue: () => {
-            const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-            const nanoid = customAlphabet(alphabet, 14)
+          name: 'purchased_by',
+          type: 'relationship',
+          label: 'Purchased By',
+          relationTo: ['users'],
+          hasMany: false,
+          defaultValue: ({ user }: { user: User }) => {
+            if (!user) return undefined
 
-            return nanoid()
+            return { relationTo: 'users', value: user?.id }
           },
           admin: {
-            description: 'Auto-generated unique ticket number.',
-            readOnly: true,
+            description: 'The user who purchased this ticket.',
+          },
+          hooks: {
+            beforeChange: [assignUserId],
           },
         },
-        ...NumberField(
-          {
-            name: 'ticket_price',
-            label: 'Ticket Price',
-            required: true,
-            admin: {
-              description: 'Enter the price in dollars',
-              placeholder: '199.99',
-            },
-          },
-          {
-            prefix: '$ ',
-            thousandSeparator: ',',
-            decimalScale: 2,
-            fixedDecimalScale: true,
-          },
-        ),
       ],
     },
-    { ...customContestRelationshipField },
     {
-      name: 'purchased_by',
-      type: 'relationship',
-      label: 'Purchased By',
-      relationTo: ['users'],
-      hasMany: false,
-      defaultValue: ({ user }: { user: User }) => {
-        if (!user) return undefined
+      name: 'ticket_number',
+      type: 'text',
+      label: 'Ticket Number',
+      unique: true,
+      defaultValue: () => {
+        const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        const nanoid = customAlphabet(alphabet, 14)
 
-        return { relationTo: 'users', value: user?.id }
+        return nanoid()
       },
       admin: {
-        description: 'The user who purchased this ticket.',
+        description: 'Auto-generated unique ticket number.',
         position: 'sidebar',
-      },
-      hooks: {
-        beforeChange: [assignUserId],
+        readOnly: true,
       },
     },
+    ...NumberField(
+      {
+        name: 'ticket_price',
+        label: 'Ticket Price',
+        required: true,
+        admin: {
+          description: 'Enter the price in dollars',
+          placeholder: '199.99',
+          position: 'sidebar',
+          readOnly: true,
+        },
+      },
+      {
+        prefix: '$ ',
+        thousandSeparator: ',',
+        decimalScale: 2,
+        fixedDecimalScale: true,
+      },
+    ),
   ],
 }
 

--- a/src/collections/Ticket/index.ts
+++ b/src/collections/Ticket/index.ts
@@ -3,6 +3,7 @@ import { customAlphabet } from 'nanoid'
 import { CollectionConfig } from 'payload/types'
 import { User } from '../../payload-types'
 import { isManagerOrAdminOrSelf } from './access/isManagerOrAdminOrSelf'
+import { customContestRelationshipField } from './custom/custom-contest-relationship-field/field'
 import { assignUserId } from './field-level-hooks/assignUserId'
 import { updateContestAfterCreate } from './hooks/updateContestAfterCreate'
 import { updateContestAfterDelete } from './hooks/updateContestAfterDelete'
@@ -62,29 +63,7 @@ const Ticket: CollectionConfig = {
         ),
       ],
     },
-    {
-      name: 'contest_id',
-      type: 'relationship',
-      label: 'Contest Id',
-      relationTo: ['contest'],
-      hasMany: false,
-      required: true,
-      admin: {
-        description: 'The contest associated with this ticket.',
-        position: 'sidebar',
-      },
-      filterOptions: ({ relationTo, data, id }) => {
-        if (relationTo === 'contest') {
-          return {
-            contest_status: {
-              equals: false,
-            },
-          }
-        }
-
-        return false
-      },
-    },
+    { ...customContestRelationshipField },
     {
       name: 'purchased_by',
       type: 'relationship',


### PR DESCRIPTION
Created a new custom relationship field for contest in ticket collection to achieve the auto fill of ticket price field.


Related Issue worked on: #138 

### **Recourses used:**

- Used ideology from

    https://github.com/contentql/pin-lottery/tree/custom-field-test-mp
    https://github.com/payloadcms/custom-field-guide
    https://payloadcms.com/blog/building-a-custom-field

- for custom dropdown:
    https://www.youtube.com/watch?v=Efn9OxSjA6Y

- Mostly related to relationship field:
    https://github.com/JessChowdhury/custom-select/blob/master/src/fields/customSelect/component.tsx
    https://github.com/payloadcms/payload/blob/1.x/src/admin/components/forms/field-types/Relationship/index.tsx
    https://payloadcms.com/community-help/github/customising-the-appearance-of-the-relationship-field

- Hooks used: (useFiled and useFromFields):

    https://payloadcms.com/docs/admin/hooks#usetablecolumns